### PR TITLE
Version 2.0.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,12 +2,14 @@
 * text=auto
 
 # Do not put this files on a distribution package (by .gitignore)
+/tools/                         export-ignore
 /vendor/                        export-ignore
 /composer.lock                  export-ignore
 /tests/public/www.sat.gob.mx    export-ignore
 
 # Do not put this files on a distribution package
 /.github/                       export-ignore
+/.phive/                        export-ignore
 /build/                         export-ignore
 /tests/                         export-ignore
 /.gitattributes                 export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,7 +12,7 @@
 /tests/                         export-ignore
 /.gitattributes                 export-ignore
 /.gitignore                     export-ignore
-/.php_cs.dist                   export-ignore
+/.php-cs-fixer.dist.php         export-ignore
 /.scrutinizer.yml               export-ignore
 /phpcs.xml.dist                 export-ignore
 /phpstan.neon.dist              export-ignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install tests/public/www.sat.gob.mx
+        run: |
+          if [ -z "$(which wget)" ]; then
+            apt-get -q update
+            apt-get -q install wget
+          fi
+          cd tests/public
+          rm -r -f www.sat.gob.mx
+          wget -r -i sat-urls.txt
+          find -type f -name "*.x*" -exec sed -i 's#http://www.sat.gob.mx/sitio_internet#http://localhost:8999/www.sat.gob.mx/sitio_internet#g' "{}" \;
+
       # see https://github.com/marketplace/actions/setup-php-action
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           extensions: filter, fileinfo, dom
           coverage: none
-          tools: composer:v2, cs2pr
+          tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan, psalm
         env:
           fail-fast: true
 
@@ -60,16 +60,16 @@ jobs:
         run: composer upgrade --no-interaction --no-progress --prefer-dist
 
       - name: Code style (phpcs)
-        run: vendor/bin/phpcs -q --report=checkstyle | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
       - name: Code style (php-cs-fixer)
-        run: vendor/bin/php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
       - name: Unit tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
 
       - name: Code analysis (phpstan)
-        run: vendor/bin/phpstan analyse --no-progress --verbose
+        run: phpstan analyse --no-progress
 
       - name: Code analysis (psalm)
-        run: vendor/bin/phpstan
+        run: psalm analyse --no-progress

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,135 @@
 name: build
 on:
   pull_request:
-    branches:
-      - master
+    branches: [ "master" ]
   push:
-    branches:
-      - master
+    branches: [ "master" ]
   schedule:
     - cron: '0 16 * * 0' # sunday 16:00
 
+# Actions
+# shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+
 jobs:
-  build:
-    name: PHP ${{ matrix.php-versions }}
+
+  phpcs:
+    name: Code style (phpcs)
     runs-on: "ubuntu-latest"
-
-    strategy:
-      matrix:
-        php-versions: ['7.3', '7.4', '8.0']
-
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, cs2pr, phpcs
+        env:
+          fail-fast: true
+      - name: Code style (phpcs)
+        run: phpcs -q --report=checkstyle | cs2pr
 
+  php-cs-fixer:
+    name: Code style (php-cs-fixer)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, cs2pr, php-cs-fixer
+        env:
+          fail-fast: true
+      - name: Code style (php-cs-fixer)
+        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+
+  phpstan:
+    name: Code analysis (phpstan)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, phpstan
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: PHPStan
+        run: phpstan analyse --no-progress
+
+  psalm:
+    name: Code analysis (psalm)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: composer:v2, psalm
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Psalm
+        run: psalm --no-progress
+
+  tests:
+    name: Tests on PHP ${{ matrix.php-versions }}
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: none
+          tools: composer:v2
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Install tests/public/www.sat.gob.mx
         run: |
           if [ -z "$(which wget)" ]; then
@@ -33,43 +140,5 @@ jobs:
           rm -r -f www.sat.gob.mx
           wget -r -i sat-urls.txt
           find -type f -name "*.x*" -exec sed -i 's#http://www.sat.gob.mx/sitio_internet#http://localhost:8999/www.sat.gob.mx/sitio_internet#g' "{}" \;
-
-      # see https://github.com/marketplace/actions/setup-php-action
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: filter, fileinfo, dom
-          coverage: none
-          tools: composer:v2, cs2pr, phpcs, php-cs-fixer, phpstan, psalm
-        env:
-          fail-fast: true
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
-
-      - name: Install project dependencies
-        run: composer upgrade --no-interaction --no-progress --prefer-dist
-
-      - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle | cs2pr
-
-      - name: Code style (php-cs-fixer)
-        run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
-
-      - name: Unit tests (phpunit)
+      - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
-
-      - name: Code analysis (phpstan)
-        run: phpstan analyse --no-progress
-
-      - name: Code analysis (psalm)
-        run: psalm analyse --no-progress

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # do not include this files on git
+/tools
 /vendor
 /composer.lock
 /tests/public/www.sat.gob.mx

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phive xmlns="https://phar.io/phive">
+  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.6.0" installed="3.6.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpstan" version="^1.4.6" installed="1.4.6" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="^4.21.0" installed="4.21.0" location="./tools/psalm" copy="false"/>
+</phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -46,6 +46,6 @@ return (new PhpCsFixer\Config())
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->append([__FILE__])
-            ->exclude(['vendor', 'build'])
+            ->exclude(['tools', 'vendor', 'build'])
     )
 ;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,47 +1,51 @@
 <?php
+
+/**
+ * @noinspection PhpUndefinedClassInspection
+ * @noinspection PhpUndefinedNamespaceInspection
+ * @see https://cs.symfony.com/doc/ruleSets/
+ * @see https://cs.symfony.com/doc/rules/
+ */
+
 declare(strict_types=1);
-return PhpCsFixer\Config::create()
+
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__.'/build/.php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
-        '@PSR2' => true,
-        '@PHP70Migration' => true,
-        '@PHP70Migration:risky' => true,
+        '@PSR12' => true,
+        '@PSR12:risky' => true,
+        '@PHP71Migration:risky' => true,
+        'void_return' => false,
+        '@PHP73Migration' => true,
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'no_alias_functions' => true,
-        'trailing_comma_in_multiline_array' => true,
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'self_accessor' => true,
         'no_trailing_comma_in_singleline_array' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
-        // contrib
         'concat_space' => ['spacing' => 'one'],
-        'not_operator_with_successor_space' => true,
-        'single_blank_line_before_namespace' => true,
         'linebreak_after_opening_tag' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
+        // symfony:risky
+        'no_alias_functions' => true,
+        'self_accessor' => true,
+        // contrib
+        'not_operator_with_successor_space' => true,
     ])
     ->setFinder(
-        PhpCsFixer\Finder::create()->in([
-            __DIR__ . '/src',
-            __DIR__ . '/tests',
-        ])
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__)
+            ->append([__FILE__])
+            ->exclude(['vendor', 'build'])
     )
 ;

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,12 +1,12 @@
 filter:
   excluded_paths:
     - 'tests/'
+    - 'tools/'
     - 'vendor/'
 
 build:
   dependencies:
     override:
-      - composer remove squizlabs/php_codesniffer friendsofphp/php-cs-fixer vimeo/psalm phpstan/phpstan --dev --no-interaction --no-progress --no-update
       - composer update --no-interaction --no-progress
   nodes:
     php:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,16 +61,16 @@ When you do begin working on your feature, here are some guidelines to consider:
 
 ## Update dependencies
 
-Install project dependencies
+Install project dependencies using [`composer`](https://getcomposer.org/download/).
 
 ```
 composer update
 ```
 
-Install development dependencies
+Install development dependencies using [`phive`](https://phar.io/).
 
 ```
-composer update
+phive update
 ```
 
 ## Check the code style
@@ -79,7 +79,7 @@ If you are having issues with coding standars use `php-cs-fixer` and `phpcbf`
 
 ```shell
 tools/php-cs-fixer fix -v
-tools/phpcbf src/ tests/
+tools/phpcbf -sp
 ```
 
 ## Running Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,13 +59,27 @@ When you do begin working on your feature, here are some guidelines to consider:
 * **Submit one feature per pull request.** If you have multiple features you wish to submit, please break them up into separate pull requests.
 * **Send coherent history**. Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please squash them before submitting.
 
+## Update dependencies
+
+Install project dependencies
+
+```
+composer update
+```
+
+Install development dependencies
+
+```
+composer update
+```
+
 ## Check the code style
 
 If you are having issues with coding standars use `php-cs-fixer` and `phpcbf`
 
 ```shell
-vendor/bin/php-cs-fixer fix -v
-vendor/bin/phpcbf src/ tests/
+tools/php-cs-fixer fix -v
+tools/phpcbf src/ tests/
 ```
 
 ## Running Tests
@@ -75,11 +89,11 @@ If any of these do not pass, it will result in a complete build failure.
 Before you can run these, be sure to `composer install` or `composer update`.
 
 ```shell
-vendor/bin/phpcs -sp
-vendor/bin/php-cs-fixer fix --dry-run -v
-vendor/bin/phpunit --testdox
-vendor/bin/phpstan analyze
-vendor/bin/psalm
+tools/phpcs -sp
+tools/php-cs-fixer fix --dry-run -v
+vendor/bin/phpunit --testdox --verbose
+tools/phpstan analyze
+tools/psalm
 ```
 
 There are some tests that require you to download big samples, please read [tests/public/README.md](tests/public/README.md) to

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 2021 Carlos C Soto
+Copyright (c) 2016 - 2022 Carlos C Soto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `Eclipxe/XmlResourceRetriever`
 
 [![Source Code][badge-source]][source]
+[![Packagist PHP Version Support][badge-php-version]][php-version]
 [![Latest Version][badge-release]][release]
 [![Software License][badge-license]][license]
 [![Build Status][badge-build]][build]
@@ -79,6 +80,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [todo]: https://github.com/eclipxe13/XmlResourceRetriever/blob/master/docs/TODO.md
 
 [source]: https://github.com/eclipxe13/XmlResourceRetriever
+[php-version]: https://packagist.org/packages/eclipxe/XmlResourceRetriever
 [release]: https://github.com/eclipxe13/XmlResourceRetriever/releases
 [license]: https://github.com/eclipxe13/XmlResourceRetriever/blob/master/LICENSE
 [build]: https://github.com/eclipxe13/XmlResourceRetriever/actions/workflows/build.yml?query=branch:master
@@ -86,10 +88,11 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [coverage]: https://scrutinizer-ci.com/g/eclipxe13/XmlResourceRetriever/code-structure/master/code-coverage
 [downloads]: https://packagist.org/packages/eclipxe/XmlResourceRetriever
 
-[badge-source]: https://img.shields.io/badge/source-eclipxe13/XmlResourceRetriever-blue.svg?style=flat-square
-[badge-release]: https://img.shields.io/github/release/eclipxe13/XmlResourceRetriever.svg?style=flat-square
-[badge-license]: https://img.shields.io/github/license/eclipxe13/XmlResourceRetriever.svg?style=flat-square
+[badge-source]: https://img.shields.io/badge/source-eclipxe13/XmlResourceRetriever-blue?style=flat-square
+[badge-php-version]: https://img.shields.io/packagist/php-v/eclipxe/XmlResourceRetriever?style=flat-square
+[badge-release]: https://img.shields.io/github/release/eclipxe13/XmlResourceRetriever?style=flat-square
+[badge-license]: https://img.shields.io/github/license/eclipxe13/XmlResourceRetriever?style=flat-square
 [badge-build]: https://img.shields.io/github/workflow/status/eclipxe13/XmlResourceRetriever/build/master?style=flat-square
-[badge-quality]: https://img.shields.io/scrutinizer/g/eclipxe13/XmlResourceRetriever/master.svg?style=flat-square
-[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/eclipxe13/XmlResourceRetriever/master.svg?style=flat-square
-[badge-downloads]: https://img.shields.io/packagist/dt/eclipxe/XmlResourceRetriever.svg?style=flat-square
+[badge-quality]: https://img.shields.io/scrutinizer/g/eclipxe13/XmlResourceRetriever/master?style=flat-square
+[badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/eclipxe13/XmlResourceRetriever/master?style=flat-square
+[badge-downloads]: https://img.shields.io/packagist/dt/eclipxe/XmlResourceRetriever?style=flat-square

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These methods apply to `XslRetriever` and `XsltRetriever`
 
 ## PHP Support
 
-This library is compatible with latest [PHP supported version](https://www.php.net/supported-versions.php) and above.
+This library is compatible with the latest [PHP supported version](https://www.php.net/supported-versions.php) and above.
 Please, try to use the full potential of the language.
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,7 @@
         "ext-dom": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.6.2",
-        "friendsofphp/php-cs-fixer": "^3.6.0",
-        "phpstan/phpstan": "^1.4.6",
-        "vimeo/psalm": "^4.21.0"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
@@ -37,18 +33,18 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:test"],
         "dev:check-style": [
-            "@php vendor/bin/php-cs-fixer fix --dry-run --verbose",
-            "@php vendor/bin/phpcs --colors -sp"
+            "@php tools/php-cs-fixer fix --dry-run --verbose",
+            "@php tools/phpcs --colors -sp"
         ],
         "dev:fix-style": [
-            "@php vendor/bin/php-cs-fixer fix --verbose",
-            "@php vendor/bin/phpcbf --colors -sp"
+            "@php tools/php-cs-fixer fix --verbose",
+            "@php tools/phpcbf --colors -sp"
         ],
         "dev:test": [
             "@dev:check-style",
             "@php vendor/bin/phpunit --testdox --verbose",
-            "@php vendor/bin/phpstan analyse --no-progress --verbose",
-            "@php vendor/bin/psalm --no-progress"
+            "@php tools/phpstan analyse --no-progress",
+            "@php tools/psalm --no-progress"
         ],
         "dev:coverage": [
             "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         {
             "name": "Carlos C Soto",
             "email": "eclipxe13@gmail.com",
-            "homepage": "http://eclipxe.com.mx"
+            "homepage": "https://eclipxe.com.mx"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6.2",
         "friendsofphp/php-cs-fixer": "^3.6.0",
-        "phpstan/phpstan": "^0.12.83",
+        "phpstan/phpstan": "^1.4.6",
         "vimeo/psalm": "^4.21.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.5.8",
+        "squizlabs/php_codesniffer": "^3.6.2",
         "friendsofphp/php-cs-fixer": "^3.6.0",
         "phpstan/phpstan": "^0.12.83",
         "vimeo/psalm": "^4.21.0"

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.5.8",
-        "friendsofphp/php-cs-fixer": "^2.18.4",
+        "friendsofphp/php-cs-fixer": "^3.6.0",
         "phpstan/phpstan": "^0.12.83",
-        "vimeo/psalm": "^3.18.2"
+        "vimeo/psalm": "^4.21.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Notice: This library follows [SEMVER 2.0.0](https://semver.org/spec/v2.0.0.html) convention.
 
+## Version 2.0.1 2022-02-25
+
+- Update license year. Happy 2022.
+- Improve GitHub Workflow CI:
+  - Split steps into jobs.
+  - Install SAT files to test complex structures.
+  - Add PHP 8.1 to test matrix.
+- Update grammar and add PHP version.
+- Update development tools:
+  - Move tools from `composer` and `vendor/bin/` to `phive` and `tools/`.
+  - Upgrade `php-cs-fixer` to version 3.6.
+  - Remove deprecated attibute `totallyTyped` on `psalm.xml.dist`.
+- Update contributing guide.
+- Update files included on distribution package.
+- Update guide to update `tests/public/www.sat.gob.mx`.
+
 ## Version 2.0.0 2021-04-03
 
 - This version changes the namespace to `Eclipxe\XmlResourceRetriever`.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,3 +4,9 @@
   In this way it would be possible to use flysystem inside the Retriever.
 - Create script to run in common line interface `bin/xml-resource-retriever`.
 - Add docblocks to all public methods and create docs based on that.
+
+## Backward compatibility changes
+
+The following changes produces a BC break. Requires a new major version.
+
+- Add return type `void` on `DownloaderInterface::downloadTo`.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -4,13 +4,17 @@
     name="Personal"
 >
   <description>Personal coding standard.</description>
+
   <arg name="tab-width" value="4"/>
   <arg name="encoding" value="utf-8"/>
   <arg name="report-width" value="auto"/>
   <arg name="extensions" value="php"/>
+  <arg name="cache" value="build/phpcs.cache"/>
+
   <file>src/</file>
   <file>tests/</file>
-  <rule ref="PSR2"/>
+
+  <rule ref="PSR12"/>
   <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
   <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
   <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,4 +3,3 @@ parameters:
     paths:
         - src/
         - tests/
-    inferPrivatePropertyTypeFromConstructor: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    cacheResultFile="build/phpunit.result.cache"
     bootstrap="./tests/bootstrap.php"
-    colors="true"
->
+    colors="true">
   <coverage>
     <include>
       <directory suffix=".php">./src/</directory>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -2,7 +2,7 @@
 <psalm xmlns="https://getpsalm.org/schema/config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    totallyTyped="true"
+    errorLevel="1"
     resolveFromConfigFile="true"
 >
   <projectFiles>

--- a/src/AbstractBaseRetriever.php
+++ b/src/AbstractBaseRetriever.php
@@ -50,7 +50,7 @@ abstract class AbstractBaseRetriever implements RetrieverInterface
     public function __construct(string $basePath, DownloaderInterface $downloader = null)
     {
         $this->basePath = $basePath;
-        $this->setDownloader($downloader ? : new PhpDownloader());
+        $this->setDownloader($downloader ?: new PhpDownloader());
     }
 
     public function getBasePath(): string

--- a/src/AbstractXmlRetriever.php
+++ b/src/AbstractXmlRetriever.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Eclipxe\XmlResourceRetriever;
 
 use DOMDocument;
-use DOMElement;
 use finfo;
 use RuntimeException;
 
@@ -88,7 +87,6 @@ abstract class AbstractXmlRetriever extends AbstractBaseRetriever implements Ret
         $modified = false;
         $elements = $document->getElementsByTagNameNS($this->searchNamespace(), $tagName);
         foreach ($elements as $element) {
-            /** @var DOMElement $element */
             if (! $element->hasAttribute($attributeName)) {
                 continue;
             }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -62,6 +62,6 @@ class Utils
                 return static::simplifyPath(implode('/', $parts));
             }
         }
-        return array_values($parts);
+        return $parts;
     }
 }

--- a/tests/Unit/XsdRetrieverTest.php
+++ b/tests/Unit/XsdRetrieverTest.php
@@ -44,7 +44,7 @@ final class XsdRetrieverTest extends RetrieverTestCase
             function (string $url): string {
                 return str_replace('http://www.sat.gob.mx/sitio_internet/', '', trim($url));
             },
-            preg_grep('/xsd$/', explode(PHP_EOL, file_get_contents($pathSatUrls) ?: ''))
+            preg_grep('/xsd$/', explode(PHP_EOL, file_get_contents($pathSatUrls) ?: '')) ?: []
         );
         // verify path of downloaded file
         $retriever->retrieve($remote);

--- a/tests/Unit/XsdRetrieverTest.php
+++ b/tests/Unit/XsdRetrieverTest.php
@@ -31,7 +31,8 @@ final class XsdRetrieverTest extends RetrieverTestCase
 
     public function testRetrieveComplexStructure(): void
     {
-        if (! is_dir($this->publicPath('www.sat.gob.mx'))) {
+        $pathSatUrls = $this->publicPath('sat-urls.txt');
+        if (! is_dir($this->publicPath('www.sat.gob.mx')) || ! is_file($pathSatUrls)) {
             $this->markTestSkipped('Download complex structures from www.sat.gob.mx to run this test');
         }
         $localPath = $this->buildPath('SATXSD');
@@ -39,11 +40,12 @@ final class XsdRetrieverTest extends RetrieverTestCase
         $remotePrefix = 'http://localhost:8999/www.sat.gob.mx/sitio_internet/';
         $remote = $remotePrefix . 'cfd/3/cfdv33.xsd';
         $retriever = new XsdRetriever($localPath);
-        $expectedRemotes = [
-            'cfd/3/cfdv33.xsd',
-            'cfd/tipoDatos/tdCFDI/tdCFDI.xsd',
-            'cfd/catalogos/catCFDI.xsd',
-        ];
+        $expectedRemotes = array_map(
+            function (string $url): string {
+                return str_replace('http://www.sat.gob.mx/sitio_internet/', '', trim($url));
+            },
+            preg_grep('/xsd$/', explode(PHP_EOL, file_get_contents($pathSatUrls) ?: ''))
+        );
         // verify path of downloaded file
         $retriever->retrieve($remote);
         // verify file exists

--- a/tests/Unit/XsltRetrieverTest.php
+++ b/tests/Unit/XsltRetrieverTest.php
@@ -44,7 +44,7 @@ final class XsltRetrieverTest extends RetrieverTestCase
             function (string $url): string {
                 return str_replace('http://www.sat.gob.mx/sitio_internet/', '', trim($url));
             },
-            preg_grep('/xslt$/', explode(PHP_EOL, file_get_contents($pathSatUrls) ?: ''))
+            preg_grep('/xslt$/', explode(PHP_EOL, file_get_contents($pathSatUrls) ?: '')) ?: []
         );
         // verify path of downloaded file
         $retriever->retrieve($remote);

--- a/tests/Unit/XsltRetrieverTest.php
+++ b/tests/Unit/XsltRetrieverTest.php
@@ -31,7 +31,8 @@ final class XsltRetrieverTest extends RetrieverTestCase
 
     public function testRetrieveComplexStructure(): void
     {
-        if (! is_dir($this->publicPath('www.sat.gob.mx'))) {
+        $pathSatUrls = $this->publicPath('sat-urls.txt');
+        if (! is_dir($this->publicPath('www.sat.gob.mx')) || ! is_file($pathSatUrls)) {
             $this->markTestSkipped('Download complex structures from www.sat.gob.mx to run this test');
         }
         $localPath = $this->buildPath('SATXSLT');
@@ -39,35 +40,12 @@ final class XsltRetrieverTest extends RetrieverTestCase
         $remotePrefix = 'http://localhost:8999/www.sat.gob.mx/sitio_internet/';
         $remote = $remotePrefix . 'cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt';
         $retriever = new XsltRetriever($localPath);
-        $expectedRemotes = [
-            'cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt',
-            'cfd/2/cadenaoriginal_2_0/utilerias.xslt',
-            'cfd/EstadoDeCuentaCombustible/ecc11.xslt',
-            'cfd/donat/donat11.xslt',
-            'cfd/divisas/divisas.xslt',
-            'cfd/implocal/implocal.xslt',
-            'cfd/leyendasFiscales/leyendasFisc.xslt',
-            'cfd/pfic/pfic.xslt',
-            'cfd/TuristaPasajeroExtranjero/TuristaPasajeroExtranjero.xslt',
-            'cfd/nomina/nomina12.xslt',
-            'cfd/cfdiregistrofiscal/cfdiregistrofiscal.xslt',
-            'cfd/pagoenespecie/pagoenespecie.xslt',
-            'cfd/aerolineas/aerolineas.xslt',
-            'cfd/valesdedespensa/valesdedespensa.xslt',
-            'cfd/consumodecombustibles/consumodecombustibles.xslt',
-            'cfd/notariospublicos/notariospublicos.xslt',
-            'cfd/vehiculousado/vehiculousado.xslt',
-            'cfd/servicioparcialconstruccion/servicioparcialconstruccion.xslt',
-            'cfd/renovacionysustitucionvehiculos/renovacionysustitucionvehiculos.xslt',
-            'cfd/certificadodestruccion/certificadodedestruccion.xslt',
-            'cfd/arteantiguedades/obrasarteantiguedades.xslt',
-            'cfd/ComercioExterior11/ComercioExterior11.xslt',
-            'cfd/ine/ine11.xslt',
-            'cfd/iedu/iedu.xslt',
-            'cfd/ventavehiculos/ventavehiculos11.xslt',
-            'cfd/terceros/terceros11.xslt',
-            'cfd/Pagos/Pagos10.xslt',
-        ];
+        $expectedRemotes = array_map(
+            function (string $url): string {
+                return str_replace('http://www.sat.gob.mx/sitio_internet/', '', trim($url));
+            },
+            preg_grep('/xslt$/', explode(PHP_EOL, file_get_contents($pathSatUrls) ?: ''))
+        );
         // verify path of downloaded file
         $retriever->retrieve($remote);
         // verify file exists

--- a/tests/public/README.md
+++ b/tests/public/README.md
@@ -4,8 +4,8 @@ This folder is used to perform tests, is the public root folder for PHP intetnal
 php -S 127.0.0.1:8999 -t tests/public/
 ```
 
-As I was unable to create complex structures for XSD and XSLT files, I had taken from
-Mexico SAT Goverment site base urls:
+As I was unable to create complex structures for XSD and XSLT files-
+I had taken from Mexico SAT Goverment:
 
 - http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd
 - http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt
@@ -15,9 +15,18 @@ To get a local copy you must perform:
 
 ```shell
 rm -rf www.sat.gob.mx
-wget -r -i urls.txt
-find -type f -name "*.x*" -exec sed -i 's/www.sat.gob.mx\/sitio_internet/localhost:8999\/www.sat.gob.mx\/sitio_internet/g' "{}" \;
+wget -q -r -i sat-urls.txt
+find -type f -name "*.x*" -exec sed -i 's#http://www.sat.gob.mx/sitio_internet#http://localhost:8999/www.sat.gob.mx/sitio_internet#g' "{}" \;
 ```
 
+To update `sat-urls.txt` you can do:
 
-
+```shell
+rm sat-urls.txt
+echo http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd >> sat-urls.txt
+wget -O - -q sat-urls.txt http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd \
+  | grep -o -P 'http://www.sat.gob.mx/\S*?xsd' >> sat-urls.txt
+echo http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt >> sat-urls.txt
+wget -O - -q sat-urls.txt http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt \
+  | grep -o -P 'http://www.sat.gob.mx/\S*?xslt' >> sat-urls.txt
+```

--- a/tests/public/sat-urls.txt
+++ b/tests/public/sat-urls.txt
@@ -1,7 +1,6 @@
 http://www.sat.gob.mx/sitio_internet/cfd/3/cfdv33.xsd
 http://www.sat.gob.mx/sitio_internet/cfd/catalogos/catCFDI.xsd
 http://www.sat.gob.mx/sitio_internet/cfd/tipoDatos/tdCFDI/tdCFDI.xsd
-
 http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt
 http://www.sat.gob.mx/sitio_internet/cfd/2/cadenaoriginal_2_0/utilerias.xslt
 http://www.sat.gob.mx/sitio_internet/cfd/EstadoDeCuentaCombustible/ecc11.xslt
@@ -29,3 +28,10 @@ http://www.sat.gob.mx/sitio_internet/cfd/iedu/iedu.xslt
 http://www.sat.gob.mx/sitio_internet/cfd/ventavehiculos/ventavehiculos11.xslt
 http://www.sat.gob.mx/sitio_internet/cfd/terceros/terceros11.xslt
 http://www.sat.gob.mx/sitio_internet/cfd/Pagos/Pagos10.xslt
+http://www.sat.gob.mx/sitio_internet/cfd/detallista/detallista.xslt
+http://www.sat.gob.mx/sitio_internet/cfd/EstadoDeCuentaCombustible/ecc12.xslt
+http://www.sat.gob.mx/sitio_internet/cfd/consumodecombustibles/consumodeCombustibles11.xslt
+http://www.sat.gob.mx/sitio_internet/cfd/GastosHidrocarburos10/GastosHidrocarburos10.xslt
+http://www.sat.gob.mx/sitio_internet/cfd/IngresosHidrocarburos10/IngresosHidrocarburos.xslt
+http://www.sat.gob.mx/sitio_internet/cfd/CartaPorte/CartaPorte.xslt
+http://www.sat.gob.mx/sitio_internet/cfd/CartaPorte/CartaPorte20.xslt


### PR DESCRIPTION
- Update license year. Happy 2022.
- Improve GitHub Workflow CI:
  - Split steps into jobs.
  - Install SAT files to test complex structures.
  - Add PHP 8.1 to test matrix.
- Update grammar and add PHP version.
- Update development tools:
  - Move tools from `composer` and `vendor/bin/` to `phive` and `tools/`.
  - Upgrade `php-cs-fixer` to version 3.6.
  - Remove deprecated attibute `totallyTyped` on `psalm.xml.dist`.
- Update contributing guide.
- Update files included on distribution package.
- Update guide to update `tests/public/www.sat.gob.mx`.

This update introduced minor changes on `src/`. This is why a new version is proposed.