### PR TITLE
Compatibility with PHP 8.5 and maintenance (version 2.0.4)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,3 @@ trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
 indent_size = 2
-
-[docker-compose.yml]
-indent_size = 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # required for sudo-bot/action-scrutinizer
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.5'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -56,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -83,7 +83,7 @@ jobs:
         php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,8 @@ jobs:
       - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
 
-  code-coverage:
-    name: Create code coverage
+  scrutinizer:
+    name: Create and upload code coverage to Scrutinizer-CI
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: PHPStan
         run: phpstan analyse --no-progress
 
-  tests:
+  phpunit:
     name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 jobs:
 
   phpcs:
-    name: Coding standard (phpcs)
+    name: Coding standards (phpcs)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -27,11 +27,11 @@ jobs:
           tools: cs2pr, phpcs
         env:
           fail-fast: true
-      - name: Code style (phpcs)
+      - name: Coding standards (phpcs)
         run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
-    name: Coding standard (php-cs-fixer)
+    name: Coding standards (php-cs-fixer)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -44,7 +44,7 @@ jobs:
           tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
-      - name: Code style (php-cs-fixer)
+      - name: Coding standards (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
   phpstan:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
-      - name: PHPStan
+      - name: Code analysis (phpstan)
         run: phpstan analyse --no-progress
 
   phpunit:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 # Actions
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+# sudo-bot/action-scrutinizer@latest https://github.com/marketplace/actions/action-scrutinizer
 
 jobs:
 
@@ -115,3 +116,46 @@ jobs:
           find -type f -name "*.x*" -exec sed -i 's#http://www.sat.gob.mx/sitio_internet#http://localhost:8999/www.sat.gob.mx/sitio_internet#g' "{}" \;
       - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --verbose
+
+  code-coverage:
+    name: Create code coverage
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: xdebug
+          tools: composer:v2
+        env:
+          fail-fast: true
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install project dependencies
+        run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Install tests/public/www.sat.gob.mx
+        run: |
+          if [ -z "$(which wget)" ]; then
+            apt-get -q update
+            apt-get -q install wget
+          fi
+          cd tests/public
+          rm -r -f www.sat.gob.mx
+          wget -r -i sat-urls.txt
+          find -type f -name "*.x*" -exec sed -i 's#http://www.sat.gob.mx/sitio_internet#http://localhost:8999/www.sat.gob.mx/sitio_internet#g' "{}" \;
+      - name: Create code coverage
+        run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
+      - name: Upload code coverage to scrutinizer
+        if: ${{ !env.ACT }} # do not run if using nektos/act
+        uses: sudo-bot/action-scrutinizer@latest
+        with:
+          cli-args: "--format=php-clover build/coverage/clover.xml"

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpcs" version="^3.11.3" installed="3.11.3" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.11.3" installed="3.11.3" location="./tools/phpcbf" copy="false"/>
-  <phar name="php-cs-fixer" version="^3.69.0" installed="3.69.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpstan" version="^2.1.5" installed="2.1.5" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.92.5" installed="3.92.5" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^4.0.1" installed="4.0.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.1" installed="4.0.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.36" installed="2.1.36" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,16 +15,15 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP71Migration:risky' => true,
-        'void_return' => false,
-        '@PHP73Migration' => true,
+        '@PHP7x1Migration:risky' => true,
+        '@PHP7x3Migration' => true,
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'type_declaration_spaces' => true,
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'match']],
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -49,6 +48,6 @@ return (new PhpCsFixer\Config())
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->append([__FILE__])
-            ->exclude(['tools', 'vendor', 'build']),
+            ->exclude(['vendor', 'tools', 'build'])
     )
 ;

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,24 +1,14 @@
 filter:
-  dependency_paths:
-    - 'vendor/'
   excluded_paths:
     - 'tests/'
     - 'tools/'
 
 build:
-  dependencies:
-    override:
-      - composer update --no-interaction --no-progress --prefer-dist
+  dependencies: { override: true }
   nodes:
     analysis: # see https://scrutinizer-ci.com/docs/tools/php/php-scrutinizer/
-      environment:
-        php:
-          version: 7.4
       project_setup: { override: true }
-      tests:
-        override:
-          - php-scrutinizer-run --enable-security-analysis
-          - command: php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --testdox --coverage-clover=coverage.clover
-            coverage:
-              file: coverage.clover
-              format: clover
+      tests: { override: true }
+
+tools:
+  external_code_coverage: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,4 +113,14 @@ of `tests/public` in order to simulate retrieving contents from the internet.
 
 When the phpunit process ends, the web server instance is killed.
 
-Take a look in `tests/boostrap.php` to see how this is working.  
+Take a look in `tests/boostrap.php` to see how this is working.
+
+## Running GitHub Actions locally
+
+You can use [`act`](https://github.com/nektos/act) to run your GitHub Actions locally.
+As documented in [`actions/setup-php-action`](https://github.com/marketplace/actions/setup-php-action#local-testing-setup)
+you will need to execute the command as:
+
+```shell
+act -P ubuntu-latest=shivammathur/node:latest
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,10 @@ phive update
 If you are having issues with coding standars use `php-cs-fixer` and `phpcbf`
 
 ```shell
+# using composer
+composer dev:fix-style
+
+# or using tools individually
 tools/php-cs-fixer fix -v
 tools/phpcbf -sp
 ```
@@ -89,11 +93,14 @@ If any of these do not pass, it will result in a complete build failure.
 Before you can run these, be sure to `composer install` or `composer update`.
 
 ```shell
+# using composer
+composer dev:build
+
+# or using tools individually
 tools/phpcs -sp
-tools/php-cs-fixer fix --dry-run -v
-vendor/bin/phpunit --testdox --verbose
+tools/php-cs-fixer fix -v --dry-run
+vendor/bin/phpunit --testdox
 tools/phpstan analyze
-tools/psalm
 ```
 
 There are some tests that require you to download big samples, please read [tests/public/README.md](tests/public/README.md) to

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 - 2025 Carlos C Soto https://eclipxe.com.mx/
+Copyright (c) 2016 - 2026 Carlos C Soto https://eclipxe.com.mx/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ If you built a configurable and useful downloader class feel free to contribute 
 
 ## Installation
 
-Use [composer](https://getcomposer.org/), so please run
+Use [composer](https://getcomposer.org/), so please run:
+
 ```shell
 composer require eclipxe/xmlresourceretriever
 ```
@@ -39,7 +40,9 @@ declare(strict_types=1);
  * /project/cache/www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt
  * and all its includes and imports (currently 27 files)
  */
+
 use Eclipxe\XmlResourceRetriever\XsltRetriever;
+
 $xslt = new XsltRetriever('/project/cache');
 $local = $xslt->retrieve('http://www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt');
 echo $local; /* /project/cache/www.sat.gob.mx/sitio_internet/cfd/3/cadenaoriginal_3_3/cadenaoriginal_3_3.xslt */

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `Eclipxe/XmlResourceRetriever`
 
 [![Source Code][badge-source]][source]
-[![Packagist PHP Version Support][badge-php-version]][php-version]
+[![PHP Version][badge-php-version]][php-version]
 [![Latest Version][badge-release]][release]
 [![Software License][badge-license]][license]
 [![Build Status][badge-build]][build]

--- a/composer.json
+++ b/composer.json
@@ -46,18 +46,18 @@
         ],
         "dev:test": [
             "@dev:check-style",
-            "@php vendor/bin/phpunit --testdox --verbose",
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
             "@php tools/phpstan analyse --no-progress"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --verbose --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
-        "dev:test": "DEV: dev:check-style, phpunit and phpstan",
+        "dev:test": "DEV: run dev:fix-style, dev:check-style, phpunit and phpstan",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,10 @@
             "homepage": "https://eclipxe.com.mx"
         }
     ],
+    "support": {
+        "source": "https://github.com/eclipxe13/XmlResourceRetriever",
+        "issues": "https://github.com/eclipxe13/XmlResourceRetriever/issues"
+    },
     "require": {
         "php": ">=7.3",
         "ext-filter": "*",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@ The following changes are to development environment:
 - Update *rulesets* on `php-cs-fixer`.
 - Standarize PHPUnit file.
 - On GitHub workflows:
-    -  Add `scrutinizer` job.
+    - Add `scrutinizer` job.
     - Run actions using latest versions.
     - Run jobs using PHP 8.5.
     - Add PHP 8.5 to test matrix.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,28 @@ Notice: This library follows [SEMVER 2.0.0](https://semver.org/spec/v2.0.0.html)
 
 Changes without release are documented here.
 
+## Version 2.0.4 2026-03-19
+
+- Ensure compatibility code with PHP 8.5.
+- Update license year to 2026.
+
+The following changes are to development environment:
+
+- Add section to run GitHub actions locally on *Contributing* documentation.
+- Scrutinizer-CI: change from create code coverage online to upload it from workflows.
+- Add PHP 8.5 to test matrix.
+- Remove deprecated rule `CallTimePassByReference` on `phpcs`.
+- Update *rulesets* on `php-cs-fixer`.
+- Standarize PHPUnit file.
+- On GitHub workflows:
+    -  Add `scrutinizer` job.
+    - Run actions using latest versions.
+    - Run jobs using PHP 8.5.
+    - Add PHP 8.5 to test matrix.
+    - Improve labels an names for jobs and steps.
+- Add support section on `composer.json`.
+- Update development tools.
+
 ## Version 2.0.3 2025-02-18
 
 - Compatibilize code with PHP 8.4.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,7 +18,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
     level: max
     paths:
-        - src/
-        - tests/
+        - src
+        - tests

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,16 +2,20 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     cacheResultFile="build/phpunit.result.cache"
-    bootstrap="./tests/bootstrap.php"
+    bootstrap="tests/bootstrap.php"
+    executionOrder="depends,defects"
     colors="true">
-  <coverage>
-    <include>
-      <directory suffix=".php">./src/</directory>
-    </include>
-  </coverage>
+
   <testsuites>
     <testsuite name="default">
-      <directory suffix="Test.php">./tests/</directory>
+      <directory>tests</directory>
     </testsuite>
   </testsuites>
+
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+
 </phpunit>

--- a/src/Downloader/DownloaderInterface.php
+++ b/src/Downloader/DownloaderInterface.php
@@ -12,7 +12,6 @@ interface DownloaderInterface
      * @param string $source
      * @param string $destination
      * @throws RuntimeException if an error occurs
-     * @return void
      */
-    public function downloadTo(string $source, string $destination);
+    public function downloadTo(string $source, string $destination): void;
 }

--- a/src/Downloader/DownloaderInterface.php
+++ b/src/Downloader/DownloaderInterface.php
@@ -12,6 +12,8 @@ interface DownloaderInterface
      * @param string $source
      * @param string $destination
      * @throws RuntimeException if an error occurs
+     * @return void
      */
-    public function downloadTo(string $source, string $destination): void;
+    /** @php-cs-fixer-ignore void_return */
+    public function downloadTo(string $source, string $destination); /** @phpstan-ignore-line missingType.return */
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,9 +35,6 @@ call_user_func(function (): void {
     do {
         usleep(10000); // wait 0.01 seconds before each try
         $headers = @get_headers('http://localhost:8999/README.md') ?: [];
-        $httpResponse = '';
-        if (isset($headers[0]) && is_scalar($headers[0])) {
-            $httpResponse = (string) $headers[0];
-        }
+        $httpResponse = strval($headers[0] ?? '');
     } while (false === strpos($httpResponse, '200 OK'));
 });


### PR DESCRIPTION
- Ensure compatibility code with PHP 8.5.
- Update license year to 2026.

The following changes are to development environment:

- Add section to run GitHub actions locally on *Contributing* documentation.
- Scrutinizer-CI: change from create code coverage online to upload it from workflows.
- Add PHP 8.5 to test matrix.
- Remove deprecated rule `CallTimePassByReference` on `phpcs`.
- Update *rulesets* on `php-cs-fixer`.
- Standarize PHPUnit file.
- On GitHub workflows:
    -  Add `scrutinizer` job.
    - Run actions using latest versions.
    - Run jobs using PHP 8.5.
    - Add PHP 8.5 to test matrix.
    - Improve labels an names for jobs and steps.
- Add support section on `composer.json`.
- Update development tools.
